### PR TITLE
Don't allow `zstd` to adapt

### DIFF
--- a/lib/compression.sh
+++ b/lib/compression.sh
@@ -1,7 +1,7 @@
 # Helper function to allow compressing in a pipeline
 function compress() {
     if [[ "${COMPRESSOR}" == "zstd" ]]; then
-        zstd -q -z --adapt=min=5 -T0 "-"
+        zstd -q -z -5 -T0 "-"
     elif [[ "${COMPRESSOR}" == "none" ]]; then
         cat "-"
     else


### PR DESCRIPTION
It gets stuck sometimes, possibly because it decided to ratchet up to a
higher value, or perhaps because of the bug mentioned where with
multiple threads it seems to make very slow progress.