### PR TITLE
Try to be more BSD-compatible

### DIFF
--- a/lib/compression.sh
+++ b/lib/compression.sh
@@ -37,7 +37,7 @@ function compress_bundle() {
         # Pass the file list off to `tar` and compress it
         declare -a FILE_LIST
         readarray -t FILE_LIST < <(collect_bundle_files "${COREFILE}")
-        tar hc "${FILE_LIST[@]}" | compress > "${BUNDLE_NAME}"
+        tar -f - -h -c "${FILE_LIST[@]}" | compress > "${BUNDLE_NAME}"
     else
         # Compress the file directly
         compress <"${COREFILE}" >"${BUNDLE_NAME}"


### PR DESCRIPTION
Without `-f -` to `tar`, we run into the dreaded `Failed to open '/dev/sa0'` error.  I am following the advice of https://stackoverflow.com/questions/8687502/tar-failed-to-open-dev-sa0-error-in-freebsd on how to fix it.