### PR TITLE
Don't error if compression of coredumps fails

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -48,6 +48,7 @@ if [[ "${#CORE_DUMPS[@]}" > 0 ]]; then
     fi
 
     echo "--- Waiting upon compression/bundling finishing"
+    # Only report errors so CI isn't marked bad by issues like https://github.com/JuliaCI/julia-buildkite/issues/421
     if wait -f "${UPLOAD_PID}"; then
         echo " -> Bundling/Compression finished successfully!"
     else

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -48,6 +48,9 @@ if [[ "${#CORE_DUMPS[@]}" > 0 ]]; then
     fi
 
     echo "--- Waiting upon compression/bundling finishing"
-    wait -f "${UPLOAD_PID}"
-    echo " -> done!"
+    if wait -f "${UPLOAD_PID}"; then
+        echo " -> Bundling/Compression finished successfully!"
+    else
+        echo " -> Error occurred during bundling/compression!"
+    fi
 fi


### PR DESCRIPTION
Doesn't fix the bug that causes https://github.com/JuliaCI/julia-buildkite/issues/421 but makes it not fail the job, as that's quite disruptive.